### PR TITLE
fix installer path: use XDG base dir instead of Cargo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y curl
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    echo '. $HOME/.cargo/env' >> $HOME/.bashrc
+    echo '. $HOME/.local/bin' >> $HOME/.bashrc
 
 WORKDIR /root/local/app
 


### PR DESCRIPTION
When I was using Docker for uv, I encountered the following error
```bash
$ docker compose up --build

 => ERROR [app 6/6] RUN . $HOME/.bashrc && uv sync                                                                                0.2s
------                                                                                                                                 
 > [app 6/6] RUN . $HOME/.bashrc && uv sync:
0.121 /bin/sh: 21: .: cannot open /root/.cargo/env: No such file
------
failed to solve: process "/bin/sh -c . $HOME/.bashrc && uv sync" did not complete successfully: exit code: 2
```

This was due to a change in `uv` [Pull Request #8420](https://github.com/astral-sh/uv/pull/8420)

In this change, environment variables that depended on `Cargo` are now XDG compliant.